### PR TITLE
Adding the configuration component from Via 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# h-vialib
+
+Library functions for use with Via
+
+Usage
+-----
+
+This is an internal library, mostly of interest to maintainers of 
+[Via](https://github.com/hypothesis/via3) and related components.
+
+Some items of interest:
+
+ * [Configuration](src/h_vialib/configuration.py) - Configuration parameter management
+
+Hacking
+-------
+
+### Installing h-vialib in a development environment
+
+#### You will need
+
+* [Git](https://git-scm.com/)
+
+* [pyenv](https://github.com/pyenv/pyenv)
+  Follow the instructions in the pyenv README to install it.
+  The Homebrew method works best on macOS.
+  On Ubuntu follow the Basic GitHub Checkout method.
+
+#### Clone the git repo
+
+```terminal
+git clone https://github.com/hypothesis/h-vialib.git
+```
+
+This will download the code into a `h-vialib` directory
+in your current working directory. You need to be in the
+`h-vialib` directory for the rest of the installation
+process:
+
+```terminal
+cd h-vialib
+```
+
+#### Run the tests
+
+```terminal
+make test
+```
+
+**That's it!** You’ve finished setting up your h-vialib
+development environment. Run `make help` to see all the commands that're
+available for linting, code formatting, packaging, etc.
+
+### Updating the Cookiecutter scaffolding
+
+This project was created from the
+https://github.com/hypothesis/h-cookiecutter-pypackage/ template.
+If h-cookiecutter-pypackage itself has changed since this project was created, and
+you want to update this project with the latest changes, you can "replay" the
+cookiecutter over this project. Run:
+
+```terminal
+make template
+```
+
+**This will change the files in your working tree**, applying the latest
+updates from the h-cookiecutter-pypackage template. Inspect and test the
+changes, do any fixups that are needed, and then commit them to git and send a
+pull request.
+
+If you want `make template` to skip certain files, never changing them, add
+these files to `"options.disable_replay"` in
+[`.cookiecutter.json`](.cookiecutter.json) and commit that to git.
+
+If you want `make template` to update a file that's listed in `disable_replay`
+simply delete that file and then run `make template`, it'll recreate the file
+for you.

--- a/src/h_vialib/__init__.py
+++ b/src/h_vialib/__init__.py
@@ -1,0 +1,3 @@
+"""Library functions for Via related products."""
+
+from h_vialib.configuration import Configuration

--- a/src/h_vialib/_flat_dict.py
+++ b/src/h_vialib/_flat_dict.py
@@ -1,0 +1,62 @@
+"""Tools for representing dicts as flat lists and converting them back."""
+
+
+class FlatDict:
+    """Convert from and to a flat format for dicts."""
+
+    SEPARATOR = "."
+
+    @classmethod
+    def unflatten(cls, flat):
+        """Convert dot delimited flat data into nested dicts.
+
+        This will convert a flat dict with keys like "a.b.c" into a nested
+        dict with the same keys. With repeated elements, the last value will
+        be chosen.
+
+        :param flat: A mapping of dot delimited keys to values
+        :return: A nested dict
+        """
+
+        nested = {}
+
+        for key, value in flat.items():
+            parts = key.split(cls.SEPARATOR)
+            target = nested
+
+            # Skip the last part
+            for part in parts[:-1]:
+                target = target.setdefault(part, {})
+
+            # Finally set the last key to the value
+            target[parts[-1]] = value
+
+        return nested
+
+    @classmethod
+    def flatten(cls, nested):
+        """Flatten a nested dict into a flat dict with dot delimited keys.
+
+        :param nested: A nested dict
+        :return: A dict with dot delimited keys
+        """
+        return cls._flatten(nested)
+
+    @classmethod
+    def _flatten(cls, nested, flat=None, key_prefix=None):
+        if key_prefix is None:
+            key_prefix = ""
+        else:
+            key_prefix += cls.SEPARATOR
+
+        if flat is None:
+            flat = {}
+
+        for key, value in nested.items():
+            flat_key = key_prefix + key
+            if isinstance(value, dict):
+                cls._flatten(value, flat=flat, key_prefix=flat_key)
+            else:
+                flat[flat_key] = value
+
+        return flat

--- a/src/h_vialib/_params.py
+++ b/src/h_vialib/_params.py
@@ -1,0 +1,82 @@
+"""Logic for manipulating and separating Via, Client and non-Via params."""
+
+
+class Params:
+    """Split, separate and join Via parameters."""
+
+    # Certain configuration options include URLs which we will read, write or
+    # direct the user to. This would allow an attacker to craft a URL which
+    # could do that to a user, so we whitelist harmless parameters instead
+    # From: https://h.readthedocs.io/projects/client/en/latest/publishers/config/#config-settings
+    CLIENT_CONFIG_WHITELIST = {
+        # Things we use now
+        "openSidebar",
+        "requestConfigFromFrame",
+        # Things which seem safe
+        "enableExperimentalNewNoteButton",
+        "externalContainerSelector",
+        "focus",
+        "showHighlights",
+        "theme",
+    }
+
+    KEY_PREFIX = "via"
+
+    @classmethod
+    def separate(cls, items):
+        """Separate params into via and non-via params.
+
+        :param items: An iterable of key value pairs
+        :return: A tuple of (via, non-via) key-value lists
+        """
+
+        via_params = []
+        non_via_params = []
+
+        for key, value in items:
+            if key.split(".")[0] == cls.KEY_PREFIX:
+                via_params.append((key, value))
+            else:
+                non_via_params.append((key, value))
+
+        return via_params, non_via_params
+
+    @classmethod
+    def split(cls, merged_params):
+        """Split merged nested Via and Client params.
+
+        :param merged_params: Nested Via parameters
+        :return: A tuple of Via and Client params
+        """
+
+        via_params = merged_params.get(cls.KEY_PREFIX, {})
+        client_params = via_params.pop("client", {})
+
+        return cls._clean_params(via_params, client_params)
+
+    @classmethod
+    def join(cls, via_params, client_params):
+        """Join Via and Client params into a single nested structure.
+
+        :param via_params: Params for Via
+        :param client_params: Params to pass to the client
+        :return: A single nested dict of params
+        """
+        via_params, client_params = cls._clean_params(via_params, client_params)
+
+        return {cls.KEY_PREFIX: dict(via_params, client=client_params)}
+
+    @classmethod
+    def _clean_params(cls, via_params, client_params):
+        # Remove keys which are not in the whitelist
+        for key in set(client_params.keys()) - cls.CLIENT_CONFIG_WHITELIST:
+            client_params.pop(key)
+
+        # Handle legacy params which we can't move for now
+        client_params.setdefault("openSidebar", via_params.pop("open_sidebar", False))
+
+        # Set some defaults
+        client_params["appType"] = "via"
+        client_params.setdefault("showHighlights", True)
+
+        return via_params, client_params

--- a/src/h_vialib/configuration.py
+++ b/src/h_vialib/configuration.py
@@ -47,7 +47,7 @@ class Configuration:
         return Params.split(merged_params)
 
     @classmethod
-    def extract_from_wsgi_environment(cls, http_env):  # pragma: no cover
+    def extract_from_wsgi_environment(cls, http_env):
         """Extract Via and H config from a WSGI environment object.
 
         :param http_env: WSGI provided environment variable
@@ -58,7 +58,7 @@ class Configuration:
         return cls.extract_from_params(params)
 
     @classmethod
-    def extract_from_url(cls, url):  # pragma: no cover
+    def extract_from_url(cls, url):
         """Extract Via and H config from a URL.
 
         :param url: A URL to extract config from
@@ -69,7 +69,7 @@ class Configuration:
         return cls.extract_from_params(params)
 
     @classmethod
-    def strip_from_url(cls, url):  # pragma: no cover
+    def strip_from_url(cls, url):
         """Remove any Via configuration parameters from the URL.
 
         If the URL has no parameters left, remove the query string entirely.
@@ -87,7 +87,7 @@ class Configuration:
         return url_parts._replace(query=urlencode(non_via)).geturl()
 
     @classmethod
-    def add_to_url(cls, url, via_params, client_params):  # pragma: no cover
+    def add_to_url(cls, url, via_params, client_params):
         """Add configuration parameters to a given URL.
 
         This will merge and preserve any parameters already on the URL.
@@ -99,6 +99,7 @@ class Configuration:
         """
         url_parts = urlparse(url)
         _, non_via = Params.separate(parse_qsl(url_parts.query))
+
         flat_params = FlatDict.flatten(Params.join(via_params, client_params))
 
         non_via.extend(flat_params.items())

--- a/src/h_vialib/configuration.py
+++ b/src/h_vialib/configuration.py
@@ -1,0 +1,106 @@
+"""Tools for reading and writing Via configuration."""
+
+from urllib.parse import parse_qsl, urlencode, urlparse
+
+from h_vialib._flat_dict import FlatDict
+from h_vialib._params import Params
+
+
+class Configuration:
+    """Extracts configuration from params.
+
+    This class will extract and separate Client and Via configuration from a
+    mapping by interpreting the keys as dot delimited values.
+
+     * After splitting on '.' the parts are interpreted as nested dict keys
+     * Any keys starting with `via.*` will be processed
+     * Any keys starting with `via.client.*` will be separated out
+     * Keys for the client which don't match a whitelist are discarded
+
+    For example:
+
+    {
+        "other": "ignored",
+        "via.option": "value",
+        "via.client.nestOne.nestTwo": "value2"
+    }
+
+    Results in:
+
+     * Via: {"option": "value"}
+     * Client : {"nestOne": {"nextTwo": "value2"}}
+
+    No attempt is made to interpret the values for the client. The client will
+    get what we were given. If this was called from query parameters, that will
+    mean a string.
+    """
+
+    @classmethod
+    def extract_from_params(cls, params):
+        """Extract Via and H config from query parameters.
+
+        :param params: A mapping of query parameters
+        :return: A tuple of Via, and H config
+        """
+
+        merged_params = FlatDict.unflatten(params)
+        return Params.split(merged_params)
+
+    @classmethod
+    def extract_from_wsgi_environment(cls, http_env):  # pragma: no cover
+        """Extract Via and H config from a WSGI environment object.
+
+        :param http_env: WSGI provided environment variable
+        :return: A tuple of Via, and H config
+        """
+        params = dict(parse_qsl(http_env.get("QUERY_STRING")))
+
+        return cls.extract_from_params(params)
+
+    @classmethod
+    def extract_from_url(cls, url):  # pragma: no cover
+        """Extract Via and H config from a URL.
+
+        :param url: A URL to extract config from
+        :return: A tuple of Via, and H config
+        """
+        params = dict(parse_qsl(urlparse(url).query))
+
+        return cls.extract_from_params(params)
+
+    @classmethod
+    def strip_from_url(cls, url):  # pragma: no cover
+        """Remove any Via configuration parameters from the URL.
+
+        If the URL has no parameters left, remove the query string entirely.
+        :param url: URL to strip
+        :return: A string URL with the via parts removed
+        """
+
+        # Quick exit if this cannot contain any of our params
+        if Params.KEY_PREFIX not in url:
+            return url
+
+        url_parts = urlparse(url)
+        _, non_via = Params.separate(parse_qsl(url_parts.query))
+
+        return url_parts._replace(query=urlencode(non_via)).geturl()
+
+    @classmethod
+    def add_to_url(cls, url, via_params, client_params):  # pragma: no cover
+        """Add configuration parameters to a given URL.
+
+        This will merge and preserve any parameters already on the URL.
+
+        :param url: URL to extract from
+        :param via_params: Configuration to add for Via
+        :param client_params: Configuration to add for the client
+        :return: The URL with expected parameters added
+        """
+        url_parts = urlparse(url)
+        _, non_via = Params.separate(parse_qsl(url_parts.query))
+        flat_params = FlatDict.flatten(Params.join(via_params, client_params))
+
+        non_via.extend(flat_params.items())
+
+        return url_parts._replace(query=urlencode(non_via)).geturl()

--- a/tests/unit/h_vialib/_flat_dict_test.py
+++ b/tests/unit/h_vialib/_flat_dict_test.py
@@ -1,0 +1,13 @@
+from h_vialib._flat_dict import FlatDict
+
+
+class TestFlatDict:
+    NESTED = {"a": {"b": {"c": 1}}, "d": [2, 3], "e": 4}
+
+    FLAT = {"a.b.c": 1, "d": [2, 3], "e": 4}
+
+    def test_flatten(self):
+        assert FlatDict.flatten(self.NESTED) == self.FLAT
+
+    def test_unflatten(self):
+        assert FlatDict.unflatten(self.FLAT) == self.NESTED

--- a/tests/unit/h_vialib/_params_test.py
+++ b/tests/unit/h_vialib/_params_test.py
@@ -1,0 +1,78 @@
+from h_vialib._params import Params
+
+
+class TestParams:
+    def test_separate(self):
+        via_params, non_via_params = Params.separate(
+            (
+                ("via.1.key", "via"),
+                ("via.2.key", "via"),
+                ("viable", "non-via"),
+                ("other", "non-via"),
+                ("other", "non-via-duplicate"),
+            )
+        )
+
+        assert via_params == [
+            ("via.1.key", "via"),
+            ("via.2.key", "via"),
+        ]
+
+        assert non_via_params == [
+            ("viable", "non-via"),
+            ("other", "non-via"),
+            ("other", "non-via-duplicate"),
+        ]
+
+    def test_split(self):
+        via_params, client_params = Params.split(
+            {
+                "via": {
+                    "any_option": 1,
+                    # This should get moved to client params
+                    "open_sidebar": True,
+                    "client": {
+                        "focus": "allowed",
+                        "random": "blocked",
+                        "requestConfigFromFrame": {"anyNestedStuff": "allowed"},
+                    },
+                }
+            }
+        )
+
+        assert via_params == {"any_option": 1}
+        assert client_params == {
+            "openSidebar": True,
+            "focus": "allowed",
+            "requestConfigFromFrame": {"anyNestedStuff": "allowed"},
+            # Defaults
+            "appType": "via",
+            "showHighlights": True,
+        }
+
+    def test_join(self):
+        merged = Params.join(
+            via_params={
+                "any_option": 1,
+                "open_sidebar": True,
+            },
+            client_params={
+                "focus": "allowed",
+                "random": "blocked",
+                "requestConfigFromFrame": {"anyNestedStuff": "allowed"},
+            },
+        )
+
+        assert merged == {
+            "via": {
+                "any_option": 1,
+                "client": {
+                    "openSidebar": True,
+                    "focus": "allowed",
+                    "requestConfigFromFrame": {"anyNestedStuff": "allowed"},
+                    # Defaults
+                    "appType": "via",
+                    "showHighlights": True,
+                },
+            }
+        }

--- a/tests/unit/h_vialib/configuration_test.py
+++ b/tests/unit/h_vialib/configuration_test.py
@@ -1,0 +1,105 @@
+from unittest.mock import patch
+
+import pytest
+from h_matchers import Any
+
+from h_vialib.configuration import Configuration
+
+
+class FakeMultiDict:
+    """Mimic things like WebOb multivalue dicts."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def items(self):
+        yield from self._items
+
+
+class TestConfiguration:
+    def test_extract_from_params(self, param_pairs):
+        via_params, client_params = Configuration.extract_from_params(dict(param_pairs))
+
+        self.assert_correct_params(via_params, client_params)
+
+    def test_extract_from_params_with_multi_dict(self, param_pairs):
+        via_params, client_params = Configuration.extract_from_params(
+            FakeMultiDict(param_pairs)
+        )
+
+        self.assert_correct_params(via_params, client_params)
+
+    def test_extract_from_wsgi_environment(self, query_string):
+        via_params, client_params = Configuration.extract_from_wsgi_environment(
+            {"QUERY_STRING": query_string}
+        )
+
+        self.assert_correct_params(via_params, client_params)
+
+    def test_extract_from_url(self, url_with_params):
+        via_params, client_params = Configuration.extract_from_url(url_with_params)
+
+        self.assert_correct_params(via_params, client_params)
+
+    def test_strip_from_url(self, url_with_params):
+        url = Configuration.strip_from_url(url_with_params)
+
+        assert url == Any.url.matching("http://example.com").with_query(
+            (
+                ("irrelevant", "missing_1"),
+                ("irrelevant", "missing_2"),
+                ("viable", "decoy"),
+            )
+        )
+
+    @patch("h_vialib.configuration.urlparse")
+    def test_strip_from_url_shortcut_without_via_params(self, urlparse):
+        url = "http://example.com/path"
+
+        stripped_url = Configuration.strip_from_url(url)
+
+        assert stripped_url == url
+        urlparse.assert_not_called()
+
+    def test_add_to_url(self):
+        url = "http://example.com?a=1&a=2&via.client.focus=3"
+
+        url_with_config = Configuration.add_to_url(
+            url, {"option": "4"}, {"openSidebar": "5"}
+        )
+
+        assert url_with_config == Any.url.matching(url).containing_query(
+            (
+                ("a", "1"),
+                ("a", "2"),
+                ("via.option", "4"),
+                ("via.client.openSidebar", "5"),
+            )
+        )
+
+        # Original via settings are wiped
+        assert url_with_config != Any.url.containing_query({"via.client.focus": "3"})
+
+    def assert_correct_params(self, via_params, client_params):
+        assert via_params == {"setting": "setting_last"}
+        assert client_params == Any.dict.containing({"focus": "focus_last"})
+
+    @pytest.fixture
+    def url_with_params(self, query_string):
+        return f"http://example.com?{query_string}"
+
+    @pytest.fixture
+    def query_string(self, param_pairs):
+        return "&".join(f"{key}={value}" for key, value in param_pairs)
+
+    @pytest.fixture
+    def param_pairs(self):
+        return (
+            ("irrelevant", "missing_1"),
+            ("irrelevant", "missing_2"),
+            ("viable", "decoy"),
+            ("via.setting", "setting_first"),
+            ("via.setting", "setting_last"),
+            ("via.client.focus", "focus_first"),
+            ("via.client.focus", "focus_last"),
+        )


### PR DESCRIPTION
This is in use in Via 3, Via and LMS. This will be in use in the upcoming Via HTML.

This is basically the [Configuration component as it exists in Via 3](https://github.com/hypothesis/via3/blob/master/via/configuration.py) with the following changes:

 * Made distinctions between different parts of the job and split them up:
   * At the bottom there is `FlatDict` for nesting and un-nesting dot delimited things like `{"via.blah": 1}`
   * Then there is `Params` which can split apart, filter and merge via and client params
   * Then there is `Configuration` on top, which maintains the same interface and has functions for getting and setting the config into URLs etc.
 * Now fully tested
 * Pretty sure this fixed a ton of bugs / edge cases as it went too