### PR TITLE
Add a tidied up version of the JWT token stuff from ViaHTML security POC

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ platforms=Operating System :: OS Independent
 
 [options]
 install_requires =
+    pyjwt
 tests_require=
     pytest
     coverage

--- a/src/h_vialib/exceptions.py
+++ b/src/h_vialib/exceptions.py
@@ -1,0 +1,13 @@
+"""Exceptions."""
+
+
+class TokenException(Exception):
+    """A security check has failed on a token."""
+
+
+class InvalidToken(TokenException):
+    """A token is present, but failed one or more checks."""
+
+
+class MissingToken(TokenException):
+    """An expected token is missing."""

--- a/src/h_vialib/secure/__init__.py
+++ b/src/h_vialib/secure/__init__.py
@@ -1,0 +1,3 @@
+"""Security helpers."""
+
+from h_vialib.secure.expiry import quantized_expiry

--- a/src/h_vialib/secure/__init__.py
+++ b/src/h_vialib/secure/__init__.py
@@ -1,3 +1,4 @@
 """Security helpers."""
 
 from h_vialib.secure.expiry import quantized_expiry
+from h_vialib.secure.token import SecureToken, SecureURLToken, ViaSecureURLToken

--- a/src/h_vialib/secure/expiry.py
+++ b/src/h_vialib/secure/expiry.py
@@ -1,0 +1,94 @@
+"""Functions for calculating expiry."""
+
+from datetime import datetime, timedelta, timezone
+
+# An arbitrary time in the past to quantize our expiry times to
+YEAR_ZERO = datetime(year=2020, month=1, day=1, tzinfo=timezone.utc)
+
+
+def quantized_expiry(max_age, divisions=2):
+    """Create a quantized expiry time.
+
+    This allows you to repeatedly issue the same expiry time over a period of
+    time, which can be useful for generating more stable tokens, which in turn
+    can help with caching.
+
+    The idea here is to issue times which are always in the future, but "snap"
+    to fixed points `max_age / divisions` seconds long. The division is
+    required to ensure that your tokens vary between being the `max_age` in the
+    future and a fixed percentage of that age, rather than 0 without it.
+
+    A higher division will guarantee that more of your max age is preserved as
+    the minimum bound, but will issue more different tokens in that period.
+
+    The exact time returned is guaranteed be:
+        * A multiple of `max_age / divisions`
+        * At most `max_age` seconds in the future
+        * At least `max_age * (divisions - 1) / divisions` seconds in the
+        future
+
+    :param max_age: The maximum age to issue (int, or timedelta)
+    :param divisions: How many subdivisions of the max age for quantization
+    :return: A datetime object
+    """
+    max_age = _to_int(max_age)
+    quantization = max_age // divisions
+
+    # Timezone aware dates are annoying, but allow you to include the TZ in a
+    # serialisation, which is required for cookie expiry times
+    delta = datetime.now(tz=timezone.utc) - YEAR_ZERO
+
+    quantized_expire = (delta.total_seconds() // quantization) * quantization
+
+    return YEAR_ZERO + timedelta(seconds=quantized_expire + max_age)
+
+
+def as_expires(expires=None, max_age=None):
+    """Convert either an expiry time or max age to an expiry time.
+
+    :param expires: Datetime by which this token will expire
+    :param max_age: ... or max age in seconds after which this will expire
+        (or timedelta)
+    :return: An expiry datetime object
+
+    :raise ValueError: if neither expires nor max_age is specified
+    """
+
+    if expires:
+        if not isinstance(expires, datetime):
+            raise ValueError(
+                f"Expected expires to be a datetime, not: '{type(expires)}'"
+            )
+        return expires
+
+    if not max_age:
+        raise ValueError("You must specify an expiry time")
+
+    return datetime.now(tz=timezone.utc) + _to_delta(max_age)
+
+
+def _to_int(max_age):
+    if max_age is None:
+        raise ValueError("max_age cannot be None")
+
+    if isinstance(max_age, int):
+        return max_age
+
+    if isinstance(max_age, timedelta):
+        return int(max_age.total_seconds())
+
+    raise ValueError(
+        f"Expected max_age to be a timedelta or int, not: '{type(max_age)}'"
+    )
+
+
+def _to_delta(max_age):
+    if isinstance(max_age, timedelta):
+        return max_age
+
+    if isinstance(max_age, int):
+        return timedelta(seconds=max_age)
+
+    raise ValueError(
+        f"Expected max_age to be a timedelta or int, not: '{type(max_age)}'"
+    )

--- a/src/h_vialib/secure/token.py
+++ b/src/h_vialib/secure/token.py
@@ -1,0 +1,150 @@
+"""JWT based tokens which can be used to create verifiable, expiring tokens."""
+
+from urllib.parse import urlparse, urlunparse
+
+import jwt
+from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
+
+from h_vialib import Configuration
+from h_vialib.exceptions import InvalidToken, MissingToken
+from h_vialib.secure.expiry import as_expires, quantized_expiry
+
+
+class SecureToken:
+    """A standardized and simplified JWT token."""
+
+    TOKEN_ALGORITHM = "HS256"
+
+    def __init__(self, secret):
+        """Initialise a token creator.
+
+        :param secret: The secret to sign and check tokens with
+        """
+        self._secret = secret
+
+    def create(self, payload=None, expires=None, max_age=None):
+        """Create a secure token.
+
+        :param payload: Dict of information to put in the token
+        :param expires: Datetime by which this token with expire
+        :param max_age: ... or max age in seconds after which this will expire
+        :return: A JWT encoded token as a string
+
+        :raise ValueError: if neither expires nor max_age is specified
+        """
+        payload["exp"] = as_expires(expires, max_age)
+
+        return jwt.encode(payload, self._secret, self.TOKEN_ALGORITHM)
+
+    def verify(self, token):
+        """Decode a token and check for validity.
+
+        :param token: Token string to check
+        :return: The token payload if valid
+
+        :raise InvalidToken: If the token is invalid or expired
+        :raise MissingToken: If no token is provided
+        """
+        if not token:
+            raise MissingToken("Missing secure token")
+
+        try:
+            return jwt.decode(token, self._secret, self.TOKEN_ALGORITHM)
+        except InvalidSignatureError as err:
+            raise InvalidToken("Invalid secure token") from err
+        except ExpiredSignatureError as err:
+            raise InvalidToken("Expired secure token") from err
+        except DecodeError as err:
+            raise InvalidToken("Malformed secure token") from err
+
+
+class SecureURLToken(SecureToken):
+    """A secure token used for signing and checking URLs."""
+
+    def create(
+        self, url, payload, expires=None, max_age=None
+    ):  # pylint: disable=arguments-differ
+        """Create a secure token.
+
+        :param url: The URL to include in the signature
+        :param payload: Dict of information to put in the token
+        :param expires: Datetime by which this token with expire
+        :param max_age: ... or max age in seconds after which this will expire
+        :return: A JWT encoded token as a string
+
+        :raise ValueError: if neither expires nor max_age is specified, or no
+            URL is provided
+        """
+        if not url:
+            raise ValueError("A URL is required to create a token")
+
+        payload["url"] = self.normalize_url(url)
+
+        return super().create(payload, expires, max_age)
+
+    def verify(self, token, comparison_url):  # pylint: disable=arguments-differ
+        """Decode a token and check for validity and a matching URL.
+
+        :param token: Token string to check
+        :param comparison_url: URL to check against the contents of the token
+        :return: The token payload if valid
+        :raise InvalidToken: If the token is invalid or expired, or if
+            the URLs do not match
+
+        :raise MissingToken: If no token is provided
+        """
+        decoded = super().verify(token)
+
+        signed_url = decoded.get("url")
+        if not signed_url:
+            raise InvalidToken("Secure URL token contains no URL")
+
+        comparison_url = self.normalize_url(comparison_url)
+        if signed_url != comparison_url:
+            raise InvalidToken(
+                f"Secure URL token path mismatch: Got '{comparison_url}' expected '{signed_url}'"
+            )
+
+        return decoded
+
+    @classmethod
+    def normalize_url(cls, url):
+        """Normalize a URL for comparison."""
+
+        try:
+            parts = urlparse(url)
+        except ValueError:
+            # This URL is unparseable, so this is the best we can do
+            return url
+
+        # Ensure that http://example.com and http://example.com/ are considered
+        # the same
+        if not parts.path:
+            parts = parts._replace(path="/")
+
+        return urlunparse(parts)
+
+
+class ViaSecureURLToken(SecureURLToken):
+    """A token for signing proxied URLs."""
+
+    MAX_AGE = 60 * 60  # An hour
+
+    def create(self, proxied_url):  # pylint: disable=arguments-differ
+        """Create a secure token for a Via proxied URL.
+
+        :param proxied_url: The URL you intend to proxy.
+        :return: A JWT encoded token as a string
+        """
+        return super().create(
+            proxied_url, payload={}, expires=quantized_expiry(self.MAX_AGE)
+        )
+
+    @classmethod
+    def normalize_url(cls, url):
+        """Normalize a URL for comparison."""
+
+        # We strip any Via config off before comparison, to ensure config
+        # doesn't change the token, and to allow the token to be included in
+        # that config
+        return Configuration.strip_from_url(super().normalize_url(url))

--- a/tests/unit/h_vialib/secure/expiry_test.py
+++ b/tests/unit/h_vialib/secure/expiry_test.py
@@ -1,0 +1,100 @@
+from datetime import datetime as _datetime
+from datetime import timedelta, timezone
+
+import pytest
+from pytest import param
+
+from h_vialib.secure.expiry import YEAR_ZERO, as_expires, quantized_expiry
+
+
+class TestQuantizedExpiry:
+    @pytest.mark.parametrize("max_age", (99, timedelta(seconds=99)))
+    def test_it_is_quantized(self, max_age):
+        expires = quantized_expiry(max_age=max_age, divisions=3)
+
+        assert isinstance(expires, _datetime)
+        diff = expires - YEAR_ZERO
+        assert diff.total_seconds() % (99 / 3) == 0
+
+    def test_it_is_in_the_range_we_expect(self):
+        now = _datetime.now(tz=timezone.utc)
+        expires = quantized_expiry(max_age=120, divisions=4)
+
+        diff = expires - now
+
+        # It's in the future
+        assert diff > timedelta(seconds=0)
+        # It's at least max_age * divisions - 1 / divisions
+        assert diff >= timedelta(seconds=120 * (3 / 4))
+        # It's at most max_age
+        assert diff <= timedelta(seconds=120)
+
+    @pytest.mark.parametrize(
+        "max_age,divisions,time_offset,expiry_offset",
+        (
+            # One progression through seconds 0 - 8, max_age=8, divisions=2
+            param(8, 2, 0, 8, id="At the start of a period, we get the full offset"),
+            param(8, 2, 1, 8, id="Through the period we get the same offset"),
+            param(8, 2, 3, 8, id="Right before the change over, we still have it"),
+            param(8, 2, 4, 12, id="At max_age/divisions we get a new quantization"),
+            param(8, 2, 7, 12, id="And keep that one too"),
+            param(8, 2, 8, 16, id="Until we get to the next period"),
+            # Specific scenarios
+            param(8, 4, 2, 10, id="With more divisions the offset is smaller"),
+            param(8, 8, 3, 13, id="With max_age=divisions quantization is 1 second"),
+            param(9, 3, 2, 12, id="There's nothing special about even numbers"),
+        ),
+    )
+    def test_quantization(
+        self, datetime, max_age, divisions, time_offset, expiry_offset
+    ):
+        # Set it so that we are time_offset seconds past "YEAR_ZERO", making
+        # all of our time offsets small and easy to see
+        datetime.now.return_value = YEAR_ZERO + timedelta(seconds=time_offset)
+
+        expires = quantized_expiry(max_age=max_age, divisions=divisions)
+
+        offset = (expires - YEAR_ZERO).seconds
+        assert offset, expiry_offset
+
+    @pytest.mark.parametrize("max_age", (None, "foo"))
+    def test_it_raises_with_invalid_max_age(self, max_age):
+        with pytest.raises(ValueError):
+            quantized_expiry(max_age=max_age)
+
+
+class TestAsExpires:
+    def test_it_passes_through_expiry(self):
+        expires = _datetime.utcnow()
+
+        assert as_expires(expires, None) == expires
+
+    def test_it_raises_if_expires_is_not_valid(self):
+        with pytest.raises(ValueError):
+            as_expires("not a date", None)
+
+    def test_it_raises_if_max_age_is_not_valid(self):
+        with pytest.raises(ValueError):
+            as_expires(None, "not a delta")
+
+    def test_it_raise_if_no_value_is_provided(self):
+        with pytest.raises(ValueError):
+            as_expires(None, None)
+
+    @pytest.mark.parametrize("max_age", (30, timedelta(seconds=30)))
+    def test_it_calculates_an_offset(self, datetime, max_age):
+        now = datetime.now.return_value = _datetime.utcnow()
+        result = as_expires(None, max_age=max_age)
+
+        assert result == now + timedelta(seconds=30)
+
+    @pytest.mark.parametrize("max_age", (30, timedelta(seconds=30)))
+    def test_it_returns_times_with_a_timezone(self, max_age):
+        result = as_expires(None, max_age=max_age)
+
+        assert result.tzinfo == timezone.utc
+
+
+@pytest.fixture
+def datetime(patch):
+    return patch("h_vialib.secure.expiry.datetime")

--- a/tests/unit/h_vialib/secure/token_test.py
+++ b/tests/unit/h_vialib/secure/token_test.py
@@ -1,0 +1,156 @@
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import pytest
+from h_matchers import Any
+from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
+
+from h_vialib.exceptions import InvalidToken, MissingToken
+from h_vialib.secure.token import SecureToken, SecureURLToken, ViaSecureURLToken
+
+
+def decode_token(token_string):
+    return jwt.decode(token_string, "a_very_secret_secret", SecureToken.TOKEN_ALGORITHM)
+
+
+class TestSecureToken:
+    def test_create_works(self, token):
+        expires = datetime.now() + timedelta(seconds=10)
+
+        token_string = token.create({"a": 2}, expires=expires)
+
+        assert token_string == Any.string()
+        assert decode_token(token_string) == {"a": 2, "exp": Any.int()}
+
+    def test_create_works_with_a_max_age(self, token):
+        token_string = token.create({"a": 2}, max_age=10)
+
+        assert token_string == Any.string()
+        assert decode_token(token_string) == {"a": 2, "exp": Any.int()}
+
+    def test_create_fails_if_no_expiry_is_set(self, token):
+        with pytest.raises(ValueError):
+            token.create({})
+
+    def test_verify_decodes_a_good_token(self, token):
+        token_string = token.create({"a": 2}, max_age=10)
+
+        decoded = token.verify(token_string)
+
+        assert decoded == {"a": 2, "exp": Any.int()}
+
+    @pytest.mark.parametrize("token_string", (None, ""))
+    def test_verify_catches_there_being_no_value(self, token, token_string):
+        with pytest.raises(MissingToken):
+            token.verify(token_string)
+
+    @pytest.mark.parametrize(
+        "exception",
+        (
+            InvalidSignatureError,
+            ExpiredSignatureError,
+            DecodeError,
+        ),
+    )
+    def test_verify_translates_errors(self, token, jwt, exception):
+        jwt.decode.side_effect = exception
+        with pytest.raises(InvalidToken):
+            token.verify("fake_token")
+
+    @pytest.fixture
+    def token(self):
+        return SecureToken("a_very_secret_secret")
+
+    @pytest.fixture
+    def jwt(self, patch):
+        return patch("h_vialib.secure.token.jwt")
+
+
+class TestSecureURLToken:
+    def test_create_normalizes_and_packs_the_url(self, token):
+        expires = datetime.now() + timedelta(seconds=10)
+
+        token_string = token.create("http://example.com", {"a": 2}, expires)
+
+        assert token_string == Any.string()
+        assert decode_token(token_string) == {
+            "url": "http://example.com/",
+            "a": 2,
+            "exp": Any.int(),
+        }
+
+    @pytest.mark.parametrize("url", (None, ""))
+    def test_create_requires_the_url(self, token, url):
+        with pytest.raises(ValueError):
+            token.create(url, {}, max_age=10)
+
+    def test_verify_works_with_a_matching_url(self, token):
+        token_string = token.create("http://example.com", {}, max_age=10)
+
+        decoded = token.verify(token_string, "http://example.com/")
+
+        assert decoded == Any.dict.containing({"url": "http://example.com/"})
+
+    def test_verify_fails_if_there_is_no_url_in_the_token(self, token):
+        no_url_token = SecureToken(token._secret).create({}, max_age=10)
+
+        with pytest.raises(InvalidToken):
+            token.verify(no_url_token, "http://any.example.com/")
+
+    def test_verify_fails_if_there_is_url_mismatch(self, token):
+        token_string = token.create("http://example.com", {}, max_age=10)
+
+        with pytest.raises(InvalidToken):
+            token.verify(token_string, "http://DIFFERENT.example.com/")
+
+    @pytest.mark.parametrize(
+        "url,normalized",
+        (
+            ("http://example.com/", "http://example.com/"),
+            ("http://example.com", "http://example.com/"),
+            ("http://example.com]", "http://example.com]"),
+        ),
+    )
+    @pytest.mark.parametrize("query_string", ("", "?a=b"))
+    def test_normalize_url(self, token, url, normalized, query_string):
+        result = token.normalize_url(url + query_string)
+
+        assert result == normalized + query_string
+
+    @pytest.fixture
+    def token(self):
+        return SecureURLToken("a_very_secret_secret")
+
+
+class TestViaSecureURLToken:
+    def test_create_works(self, token):
+        token_string = token.create("http://example.com?via.config=blah")
+
+        assert token_string == Any.string()
+        assert decode_token(token_string) == {
+            "url": "http://example.com/",
+            "exp": Any.int(),
+        }
+
+    def test_create_uses_a_quantized_expiry(self, token, quantized_expiry):
+        quantized_expiry.return_value = datetime.now(tz=timezone.utc)
+
+        token_string = token.create("*any*")
+
+        quantized_expiry.assert_called_once_with(token.MAX_AGE)
+        assert decode_token(token_string) == Any.dict.containing(
+            {"exp": int(quantized_expiry.return_value.timestamp())}
+        )
+
+    def test_normalize_url_strips_via_params(self, token):
+        url = token.normalize_url("http://example.com?a=b&via.config=boo")
+
+        assert url == "http://example.com/?a=b"
+
+    @pytest.fixture
+    def token(self):
+        return ViaSecureURLToken("a_very_secret_secret")
+
+    @pytest.fixture
+    def quantized_expiry(self, patch):
+        return patch("h_vialib.secure.token.quantized_expiry")


### PR DESCRIPTION
This adds:

 * A basic wrappers around a JWT based tokens
 * A more specialised one for encoding and comparing paths
 * One specifically for doing this in a ViaHTML context

## Review notes

 * Nothing here is used yet, but it will be used in ViaHTML at least in: https://github.com/hypothesis/viahtml/pull/47
 * Actual usage can be seen in: https://github.com/hypothesis/viahtml/blob/lockdown-poc/viahtml/views/authentication.py
 * This is somewhat usage agnostic. Most of this could live in a totally separate lib
 * It might be a good thing to carve off into `checkmate-lib`
 * Some of the things we can do, we don't happen to yet. But this lets us experiment and change our minds. For example we mostly use exact expiry times, not not 100% of the time. We also don't pass timedeltas for max age, but passing `timedelta(hour=2)` is a lot nicer than `60 * 60 * 2`.


Here's a small script which uses this stuff to sign ViaHTML urls:

```python
from h_vialib.configuration import Configuration
from h_vialib.secure import ViaSecureURLToken


def sign_url(url, secret, via_host):
    sec = ViaSecureURLToken(secret).create(url)

    signed_url = Configuration.add_to_url(
        url, via_params={"sec": sec},
        client_params={})

    return f"{via_host}/{signed_url}"


url = "http://example.com?a=ga"
print(sign_url(url, secret="not_a_secret", via_host="http://localhost:9085/proxy"))
```