### PR TITLE
Add classes for generating verifiable but arbitrary tokens

### DIFF
--- a/src/h_vialib/secure/__init__.py
+++ b/src/h_vialib/secure/__init__.py
@@ -1,5 +1,6 @@
 """Security helpers."""
 
 from h_vialib.secure.expiry import quantized_expiry
+from h_vialib.secure.nonce import RandomSecureNonce, RepeatableSecureNonce
 from h_vialib.secure.token import SecureToken
 from h_vialib.secure.url import SecureURL, ViaSecureURL

--- a/src/h_vialib/secure/nonce.py
+++ b/src/h_vialib/secure/nonce.py
@@ -1,0 +1,23 @@
+"""Create values we can check we created."""
+
+from uuid import uuid4
+
+from h_vialib.secure.token import SecureToken
+
+
+class RandomSecureNonce(SecureToken):
+    """Source of random tokens we can verify we made with expiry."""
+
+    def create(self, expires=None, max_age=None):  # pylint: disable=arguments-differ
+        """Return a random nonce. Each call returns a different nonce."""
+        return super().create(
+            payload={"salt": uuid4().hex}, expires=expires, max_age=max_age
+        )
+
+
+class RepeatableSecureNonce(SecureToken):
+    """Source of repeatable tokens which we can verify we made with expiry."""
+
+    def create(self, expires=None):  # pylint: disable=arguments-differ
+        """Create a repeatable nonce based on the expiry."""
+        return super().create({}, expires=expires)

--- a/tests/unit/h_vialib/secure/nonce_test.py
+++ b/tests/unit/h_vialib/secure/nonce_test.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from h_vialib.exceptions import InvalidToken
+from h_vialib.secure import RandomSecureNonce, RepeatableSecureNonce
+
+
+def in_ten_seconds():
+    return datetime.now(tz=timezone.utc) + timedelta(seconds=10)
+
+
+class TestCommonNonce:
+    def test_round_trip(self, nonce):
+        nonce_string = nonce.create(expires=in_ten_seconds())
+
+        assert nonce.verify(nonce_string)
+
+    def test_we_can_detect_a_fake(self, nonce):
+        real_nonce = nonce.create(expires=in_ten_seconds())
+
+        fake_nonce = (
+            real_nonce[:10] + "G" if real_nonce[11] == "F" else "F" + real_nonce[11:]
+        )
+
+        with pytest.raises(InvalidToken):
+            nonce.verify(fake_nonce)
+
+    @pytest.fixture(params=[RandomSecureNonce, RepeatableSecureNonce])
+    def nonce(self, request):
+        return request.param("not_a_secret")
+
+
+class TestRandomSecureNonce:
+    def test_two_nonces_are_different(self, nonce):
+        expires = in_ten_seconds()
+
+        nonce_1 = nonce.create(expires=expires)
+        nonce_2 = nonce.create(expires=expires)
+
+        assert nonce_1 != nonce_2
+
+    @pytest.fixture
+    def nonce(self):
+        return RandomSecureNonce("not_a_secret")
+
+
+class TestRepeatableSecureNonce:
+    def test_two_nonces_are_the_same(self, nonce):
+        expires = in_ten_seconds()
+
+        nonce_1 = nonce.create(expires=expires)
+        nonce_2 = nonce.create(expires=expires)
+
+        assert nonce_1 == nonce_2
+
+    @pytest.fixture
+    def nonce(self):
+        return RepeatableSecureNonce("not_a_secret")


### PR DESCRIPTION
Some small helpers for creating "nonce" values. We can tell we made them, but other than that they convey no information.

This is for use in:

 * Our Via surfing cookies. We need them to exist and be verifiable, but little else
 * We could use them for our checkmate Google nonce values
 
 ## Review notes

 * Nothing here is used yet, but it will be used in ViaHTML at least in: https://github.com/hypothesis/viahtml/pull/47
 * Actual usage can be seen in: https://github.com/hypothesis/viahtml/blob/lockdown-poc/viahtml/views/authentication.py
