### PR TITLE
Add cookie helper methods for creating secure cookies

### DIFF
--- a/src/h_vialib/secure/__init__.py
+++ b/src/h_vialib/secure/__init__.py
@@ -1,5 +1,6 @@
 """Security helpers."""
 
+from h_vialib.secure.cookie import TokenBasedCookie
 from h_vialib.secure.expiry import quantized_expiry
 from h_vialib.secure.nonce import RandomSecureNonce, RepeatableSecureNonce
 from h_vialib.secure.token import SecureToken

--- a/src/h_vialib/secure/cookie.py
+++ b/src/h_vialib/secure/cookie.py
@@ -1,0 +1,122 @@
+"""Cookie helpers to create secure cookies."""
+
+from http.cookies import SimpleCookie
+
+from h_vialib.exceptions import MissingToken
+from h_vialib.secure.expiry import as_expires
+
+
+class Cookie:
+    """A simplified Cookie for security purposes."""
+
+    def __init__(self, name):
+        """Initialise this cookie object.
+
+        :param name: Cookie name to read and write
+        """
+        self._name = name
+
+    _DATE_FORMAT = "%a, %d %b %Y %H:%M:%S %Z"
+
+    def create(self, value, expires=None, max_age=None):
+        """Create a cookie with a specified value and expiry.
+
+        This cookie is for security purposes and has a number of default
+        behaviors:
+
+         * The path is '/'
+         * HTTP Only is enabled
+         * The name is controlled to be the same as this class was intialised with
+
+        :param value: The value to store in the cookie
+        :param expires: Expiry time for the cookie
+        :param max_age: ... or max age of the cookie
+        :return: A tuple of the correct header and value to set this cookie
+
+        :raises ValueError: If no expiry is provided
+        """
+        cookie = SimpleCookie()
+
+        cookie[self._name] = value
+        cookie[self._name]["path"] = "/"
+        cookie[self._name]["httponly"] = True
+
+        if expires is not None:
+            if expires.tzinfo is None:
+                raise ValueError("The expires date must have a timezone")
+
+            cookie[self._name]["expires"] = expires.strftime(self._DATE_FORMAT)
+        elif max_age is not None:
+            cookie[self._name]["max-age"] = int(max_age)
+        else:
+            raise ValueError("You must specify an expiry time")
+
+        return tuple(cookie.output().split(": "))
+
+    def verify(self, cookies_header):
+        """Check for the presence of our cookie and get the value.
+
+        :param cookies_header: Full content of the "Cookies" header
+        :returns: The value matching our name, or None
+        """
+        if not cookies_header:
+            return None
+
+        cookie = SimpleCookie(cookies_header)
+        try:
+            return cookie[self._name].value
+        except KeyError:
+            return None
+
+
+class TokenBasedCookie(Cookie):
+    """A cookie which stores it's contents using a SecureToken."""
+
+    def __init__(self, name, token_provider):
+        """Initialize the cookie.
+
+        :param name: Cookie name to read and write
+        :param token_provider: Sub-class of SecureToken to use for creating
+            and verifying the value
+        """
+        self._token_provider = token_provider
+
+        super().__init__(name)
+
+    def create(
+        self, expires=None, max_age=None, **kwargs
+    ):  # pylint: disable=arguments-differ
+        """Create a cookie.
+
+        This passes through any arguments to the underlying token provider to
+        create the value. Any arguments understood by the token provider will
+        be accepted.
+
+        :param expires: Expiry time for the cookie
+        :param max_age: ... or max age of the cookie
+        :param kwargs: Arguments to pass to the token provider
+        :return: A tuple of the correct header and value to set this cookie
+        """
+        expires = as_expires(expires, max_age)
+        token = self._token_provider.create(expires=expires, **kwargs)
+
+        return super().create(value=token, expires=expires)
+
+    def verify(self, cookies_header, **kwargs):  # pylint: disable=arguments-differ
+        """Get a cookie value and check it with the token provider.
+
+        All extra args and kwargs are passed through to the verify method
+        of the token provider.
+
+        :param cookies_header: Full content of the "Cookies" header
+        :param kwargs: Arguments to pass to the token provider
+        :returns: The decoded value of the cookie according to the token
+            provider
+
+        :raises MissingToken: If the cookie cannot be found
+        """
+        token = super().verify(cookies_header)
+        if not token:
+            raise MissingToken("No secure cookie")
+
+        return self._token_provider.verify(token, **kwargs)

--- a/tests/unit/h_vialib/secure/cookie_test.py
+++ b/tests/unit/h_vialib/secure/cookie_test.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timezone
+from unittest.mock import create_autospec
+
+import pytest
+
+from h_vialib.exceptions import MissingToken
+from h_vialib.secure import SecureToken
+from h_vialib.secure.cookie import Cookie, TokenBasedCookie
+
+
+class TestCookie:
+    def test_create(self):
+        expires = datetime(2010, 11, 21, 4, 34, 38, tzinfo=timezone.utc)
+
+        cookie = Cookie("name").create("value", expires=expires)
+
+        assert cookie == (
+            "Set-Cookie",
+            "name=value; expires=Sun, 21 Nov 2010 04:34:38 UTC; HttpOnly; Path=/",
+        )
+
+    def test_create_with_max_age(self):
+        cookie = Cookie("name").create("value", max_age=321)
+
+        assert cookie == ("Set-Cookie", "name=value; HttpOnly; Max-Age=321; Path=/")
+
+    def test_create_requires_an_expiry(self):
+        with pytest.raises(ValueError):
+            Cookie("any").create("value", expires=None, max_age=None)
+
+    def test_create_raises_if_the_expiry_has_no_timezone(self):
+        with pytest.raises(ValueError):
+            Cookie("any").create("value", expires=datetime.now())
+
+    @pytest.mark.parametrize(
+        "cookies,value",
+        (
+            ("noise=irrelevant name=value", "value"),
+            ("noise=irrelevant", None),
+            ("", None),
+            (None, None),
+        ),
+    )
+    def test_verify(self, cookies, value):
+        result = Cookie("name").verify(cookies)
+
+        assert result == value
+
+
+class TestTokenBasedCookie:
+    def test_create(self, cookie, token_provider):
+        token_provider.create.return_value = "token-value"
+        expires = datetime(2010, 11, 21, 4, 34, 38, tzinfo=timezone.utc)
+
+        result = cookie.create(
+            payload={"pass-through": "args"},
+            expires=expires,
+        )
+
+        assert result == (
+            "Set-Cookie",
+            "name=token-value; expires=Sun, 21 Nov 2010 04:34:38 UTC; HttpOnly; Path=/",
+        )
+        token_provider.create.assert_called_once_with(
+            expires=expires,
+            payload={"pass-through": "args"},
+        )
+
+    def test_verify(self, cookie, token_provider):
+        result = cookie.verify("noise=irrelevant name=token-value")
+
+        assert result == token_provider.verify.return_value
+        token_provider.verify.assert_called_once_with("token-value")
+
+    def test_verify_raises_if_cookie_missing(self, cookie):
+        with pytest.raises(MissingToken):
+            cookie.verify("noise=irrelevant")
+
+    @pytest.fixture
+    def cookie(self, token_provider):
+        return TokenBasedCookie("name", token_provider)
+
+    @pytest.fixture
+    def token_provider(self):
+        return create_autospec(SecureToken, instance=True, spec_set=True)


### PR DESCRIPTION
This is for use in combination with the nonce values in https://github.com/hypothesis/h-vialib/pull/5 to create secure cookies which we can easily check we made.

They can have any of the token values in them though, so we could put arbitrary secure tokens in them.

## Review notes

 * Nothing here is used yet, but it will be used in ViaHTML at least in: https://github.com/hypothesis/viahtml/pull/47
 * Actual usage can be seen in: https://github.com/hypothesis/viahtml/blob/lockdown-poc/viahtml/views/authentication.py