### PR TITLE
Replace SecureURLToken with SecureURL which is much simpler to use

### DIFF
--- a/src/h_vialib/secure/__init__.py
+++ b/src/h_vialib/secure/__init__.py
@@ -1,5 +1,5 @@
 """Security helpers."""
 
 from h_vialib.secure.expiry import quantized_expiry
-from h_vialib.secure.token import SecureToken, SecureURLToken, ViaSecureURLToken
+from h_vialib.secure.token import SecureToken
 from h_vialib.secure.url import SecureURL, ViaSecureURL

--- a/src/h_vialib/secure/__init__.py
+++ b/src/h_vialib/secure/__init__.py
@@ -2,3 +2,4 @@
 
 from h_vialib.secure.expiry import quantized_expiry
 from h_vialib.secure.token import SecureToken, SecureURLToken, ViaSecureURLToken
+from h_vialib.secure.url import SecureURL, ViaSecureURL

--- a/src/h_vialib/secure/token.py
+++ b/src/h_vialib/secure/token.py
@@ -1,13 +1,10 @@
 """JWT based tokens which can be used to create verifiable, expiring tokens."""
 
-from urllib.parse import urlparse, urlunparse
-
 import jwt
 from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
 
-from h_vialib import Configuration
 from h_vialib.exceptions import InvalidToken, MissingToken
-from h_vialib.secure.expiry import as_expires, quantized_expiry
+from h_vialib.secure.expiry import as_expires
 
 
 class SecureToken:
@@ -56,95 +53,3 @@ class SecureToken:
             raise InvalidToken("Expired secure token") from err
         except DecodeError as err:
             raise InvalidToken("Malformed secure token") from err
-
-
-class SecureURLToken(SecureToken):
-    """A secure token used for signing and checking URLs."""
-
-    def create(
-        self, url, payload, expires=None, max_age=None
-    ):  # pylint: disable=arguments-differ
-        """Create a secure token.
-
-        :param url: The URL to include in the signature
-        :param payload: Dict of information to put in the token
-        :param expires: Datetime by which this token with expire
-        :param max_age: ... or max age in seconds after which this will expire
-        :return: A JWT encoded token as a string
-
-        :raise ValueError: if neither expires nor max_age is specified, or no
-            URL is provided
-        """
-        if not url:
-            raise ValueError("A URL is required to create a token")
-
-        payload["url"] = self.normalize_url(url)
-
-        return super().create(payload, expires, max_age)
-
-    def verify(self, token, comparison_url):  # pylint: disable=arguments-differ
-        """Decode a token and check for validity and a matching URL.
-
-        :param token: Token string to check
-        :param comparison_url: URL to check against the contents of the token
-        :return: The token payload if valid
-        :raise InvalidToken: If the token is invalid or expired, or if
-            the URLs do not match
-
-        :raise MissingToken: If no token is provided
-        """
-        decoded = super().verify(token)
-
-        signed_url = decoded.get("url")
-        if not signed_url:
-            raise InvalidToken("Secure URL token contains no URL")
-
-        comparison_url = self.normalize_url(comparison_url)
-        if signed_url != comparison_url:
-            raise InvalidToken(
-                f"Secure URL token path mismatch: Got '{comparison_url}' expected '{signed_url}'"
-            )
-
-        return decoded
-
-    @classmethod
-    def normalize_url(cls, url):
-        """Normalize a URL for comparison."""
-
-        try:
-            parts = urlparse(url)
-        except ValueError:
-            # This URL is unparseable, so this is the best we can do
-            return url
-
-        # Ensure that http://example.com and http://example.com/ are considered
-        # the same
-        if not parts.path:
-            parts = parts._replace(path="/")
-
-        return urlunparse(parts)
-
-
-class ViaSecureURLToken(SecureURLToken):
-    """A token for signing proxied URLs."""
-
-    MAX_AGE = 60 * 60  # An hour
-
-    def create(self, proxied_url):  # pylint: disable=arguments-differ
-        """Create a secure token for a Via proxied URL.
-
-        :param proxied_url: The URL you intend to proxy.
-        :return: A JWT encoded token as a string
-        """
-        return super().create(
-            proxied_url, payload={}, expires=quantized_expiry(self.MAX_AGE)
-        )
-
-    @classmethod
-    def normalize_url(cls, url):
-        """Normalize a URL for comparison."""
-
-        # We strip any Via config off before comparison, to ensure config
-        # doesn't change the token, and to allow the token to be included in
-        # that config
-        return Configuration.strip_from_url(super().normalize_url(url))

--- a/src/h_vialib/secure/url.py
+++ b/src/h_vialib/secure/url.py
@@ -1,0 +1,108 @@
+"""Routines for signing and checking URLs."""
+
+from datetime import timedelta
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse
+
+from h_vialib.exceptions import InvalidToken
+from h_vialib.secure import SecureToken, quantized_expiry
+
+
+class SecureURL(SecureToken):
+    """Sign and check URLs with a JWT."""
+
+    def __init__(self, secret, token_param):
+        """Initialise the SecureURL.
+
+        :param secret: Secret to sign and check with
+        :param token_param: The URL parameter to use for the token
+        """
+        super().__init__(secret)
+        self._token_param = token_param
+
+    def create(
+        self, url, payload, expires=None, max_age=None
+    ):  # pylint: disable=arguments-differ
+        """Create a signed URL which can be checked with this class.
+
+        The entire URL should be added that you want to sign, without any
+        modifications. This will remove any existing signature, create a new
+        one, and append it to the URL as the parameter
+
+        :param url: The URL to sign
+        :param payload: Dict of extra information to put in the token
+        :param expires: Datetime by which this token with expire
+        :param max_age: ... or max age in seconds after which this will expire
+        :return: A URL with an extra parameter
+
+        :raise ValueError: if neither expires nor max_age is specified, or no
+            URL is provided
+        """
+        if not url:
+            raise ValueError("A URL is required to create a token")
+
+        url = self._strip_token(url)
+
+        payload["url"] = url
+        token = super().create(payload, expires, max_age)
+
+        return self._add_token(url, token)
+
+    def verify(self, url):  # pylint: disable=arguments-differ
+        """Check a URL to see if it's been signed by this service.
+
+        :param url: URL to check
+        :return: A dict of details from the token if verified
+
+        :raises InvalidToken: If the token is invalid or the URL does not match
+        """
+        token = self._get_token(url)
+        decoded = super().verify(token)
+
+        signed_url = decoded.get("url")
+        if not signed_url:
+            raise InvalidToken("Secure URL token contains no URL")
+
+        comparison_url = self._strip_token(url)
+        if signed_url != comparison_url:
+            raise InvalidToken(
+                f"Secure URL token path mismatch: Got '{comparison_url}' expected '{signed_url}'"
+            )
+
+        return decoded
+
+    def _get_token(self, url):
+        params = dict(parse_qsl(urlparse(url).query))
+
+        return params.get(self._token_param)
+
+    def _strip_token(self, url):
+        parsed_url = urlparse(url)
+        query = [
+            item for item in parse_qsl(parsed_url.query) if item[0] != self._token_param
+        ]
+
+        return parsed_url._replace(query=urlencode(query)).geturl()
+
+    def _add_token(self, url, token):
+        parsed_url = urlparse(url)
+        query = parse_qs(parsed_url.query)
+        query[self._token_param] = [token]
+
+        return parsed_url._replace(query=urlencode(query, doseq=True)).geturl()
+
+
+class ViaSecureURL(SecureURL):
+    """A token for signing proxied URLs."""
+
+    MAX_AGE = timedelta(hours=1)
+
+    def __init__(self, secret):
+        super().__init__(secret, token_param="via.sec")
+
+    def create(self, url):  # pylint: disable=arguments-differ
+        """Create a secure token for a Via proxied URL.
+
+        :param url: The whole URL of the request to Via with all params
+        :return: A JWT encoded token as a string
+        """
+        return super().create(url, payload={}, expires=quantized_expiry(self.MAX_AGE))

--- a/tests/unit/h_vialib/secure/token_test.py
+++ b/tests/unit/h_vialib/secure/token_test.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import jwt
 import pytest
@@ -6,7 +6,7 @@ from h_matchers import Any
 from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
 
 from h_vialib.exceptions import InvalidToken, MissingToken
-from h_vialib.secure.token import SecureToken, SecureURLToken, ViaSecureURLToken
+from h_vialib.secure.token import SecureToken
 
 
 def decode_token(token_string):
@@ -64,93 +64,3 @@ class TestSecureToken:
     @pytest.fixture
     def jwt(self, patch):
         return patch("h_vialib.secure.token.jwt")
-
-
-class TestSecureURLToken:
-    def test_create_normalizes_and_packs_the_url(self, token):
-        expires = datetime.now() + timedelta(seconds=10)
-
-        token_string = token.create("http://example.com", {"a": 2}, expires)
-
-        assert token_string == Any.string()
-        assert decode_token(token_string) == {
-            "url": "http://example.com/",
-            "a": 2,
-            "exp": Any.int(),
-        }
-
-    @pytest.mark.parametrize("url", (None, ""))
-    def test_create_requires_the_url(self, token, url):
-        with pytest.raises(ValueError):
-            token.create(url, {}, max_age=10)
-
-    def test_verify_works_with_a_matching_url(self, token):
-        token_string = token.create("http://example.com", {}, max_age=10)
-
-        decoded = token.verify(token_string, "http://example.com/")
-
-        assert decoded == Any.dict.containing({"url": "http://example.com/"})
-
-    def test_verify_fails_if_there_is_no_url_in_the_token(self, token):
-        no_url_token = SecureToken(token._secret).create({}, max_age=10)
-
-        with pytest.raises(InvalidToken):
-            token.verify(no_url_token, "http://any.example.com/")
-
-    def test_verify_fails_if_there_is_url_mismatch(self, token):
-        token_string = token.create("http://example.com", {}, max_age=10)
-
-        with pytest.raises(InvalidToken):
-            token.verify(token_string, "http://DIFFERENT.example.com/")
-
-    @pytest.mark.parametrize(
-        "url,normalized",
-        (
-            ("http://example.com/", "http://example.com/"),
-            ("http://example.com", "http://example.com/"),
-            ("http://example.com]", "http://example.com]"),
-        ),
-    )
-    @pytest.mark.parametrize("query_string", ("", "?a=b"))
-    def test_normalize_url(self, token, url, normalized, query_string):
-        result = token.normalize_url(url + query_string)
-
-        assert result == normalized + query_string
-
-    @pytest.fixture
-    def token(self):
-        return SecureURLToken("a_very_secret_secret")
-
-
-class TestViaSecureURLToken:
-    def test_create_works(self, token):
-        token_string = token.create("http://example.com?via.config=blah")
-
-        assert token_string == Any.string()
-        assert decode_token(token_string) == {
-            "url": "http://example.com/",
-            "exp": Any.int(),
-        }
-
-    def test_create_uses_a_quantized_expiry(self, token, quantized_expiry):
-        quantized_expiry.return_value = datetime.now(tz=timezone.utc)
-
-        token_string = token.create("*any*")
-
-        quantized_expiry.assert_called_once_with(token.MAX_AGE)
-        assert decode_token(token_string) == Any.dict.containing(
-            {"exp": int(quantized_expiry.return_value.timestamp())}
-        )
-
-    def test_normalize_url_strips_via_params(self, token):
-        url = token.normalize_url("http://example.com?a=b&via.config=boo")
-
-        assert url == "http://example.com/?a=b"
-
-    @pytest.fixture
-    def token(self):
-        return ViaSecureURLToken("a_very_secret_secret")
-
-    @pytest.fixture
-    def quantized_expiry(self, patch):
-        return patch("h_vialib.secure.token.quantized_expiry")

--- a/tests/unit/h_vialib/secure/url_test.py
+++ b/tests/unit/h_vialib/secure/url_test.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+
+import pytest
+from h_matchers import Any
+
+from h_vialib.exceptions import InvalidToken, MissingToken
+from h_vialib.secure import SecureToken
+from h_vialib.secure.url import SecureURL, ViaSecureURL
+
+
+class TestSecureURL:
+    def test_round_tripping(self, secure_url):
+        url = "http://example.com?a=1&tok.sec=OLD_TOKEN&a=2"
+
+        signed_url = secure_url.create(url, {"extra": "value"}, max_age=10)
+        decoded = secure_url.verify(signed_url)
+
+        assert signed_url == Any.url.matching(url).with_query(
+            [("a", "1"), ("a", "2"), ("tok.sec", Any.string())]
+        )
+        assert decoded == {
+            "url": "http://example.com?a=1&a=2",
+            "extra": "value",
+            "exp": Any.int(),
+        }
+
+    @pytest.mark.parametrize("bad_url", (None, ""))
+    def test_create_requires_a_url(self, secure_url, bad_url):
+        with pytest.raises(ValueError):
+            secure_url.create(bad_url, {}, max_age=10)
+
+    def test_verify_fails_with_a_missing_token(self, secure_url):
+        with pytest.raises(MissingToken):
+            secure_url.verify("http://example.com")
+
+    @pytest.mark.parametrize("payload", ({}, {"url": "http://different.example.com"}))
+    def test_verify_fails_with_bad_tokens(self, secure_url, payload):
+        # Use a vanilla secret token to make a broken token
+        url = "http://example.com?tok.sec=" + SecureToken("not_a_secret").create(
+            payload, max_age=10
+        )
+
+        with pytest.raises(InvalidToken):
+            secure_url.verify(url)
+
+    @pytest.fixture
+    def secure_url(self):
+        return SecureURL("not_a_secret", "tok.sec")
+
+
+class TestViaSecureURL:
+    def test_round_tripping(self, quantized_expiry):
+        token = ViaSecureURL("not_a_secret")
+
+        signed_url = token.create("http://example.com?via.sec=OLD_TOKEN")
+        decoded = token.verify(signed_url)
+
+        assert signed_url == Any.url.matching(signed_url).with_query(
+            {"via.sec": Any.string()}
+        )
+        assert decoded == {
+            "url": "http://example.com",
+            "exp": int(quantized_expiry.return_value.timestamp()),
+        }
+
+    @pytest.fixture
+    def quantized_expiry(self, patch):
+        quantized_expiry = patch("h_vialib.secure.url.quantized_expiry")
+        quantized_expiry.return_value = datetime.utcnow() + timedelta(seconds=10)
+
+        return quantized_expiry


### PR DESCRIPTION
This replaces a class focused on tokens with one focused on signing URLs, which is what we're actually doing. This means our different implementations can't use this in incongruous ways.

This removes the old code, and will obviously break anything that uses it. But it also radically simplifies using the code universally:

```python
secure_url = ViaSecureURL("secret")

signed_url = secure_url.create(url)
secure_url.verify(signed_url)
```