### PR TITLE
Move to fixed length hash based signatures for URLs

### DIFF
--- a/src/h_vialib/secure/url.py
+++ b/src/h_vialib/secure/url.py
@@ -13,6 +13,10 @@ from h_vialib.secure import SecureToken, quantized_expiry
 class SecureURL(SecureToken):
     """Sign and check URLs with a JWT."""
 
+    # We want to keep our tokens as skinny as possible, so we'll use a short
+    # name for the hash parameter we store inside the JWT
+    _HASH_PARAM = "h"
+
     def __init__(self, secret, token_param):
         """Initialise the SecureURL.
 
@@ -43,7 +47,7 @@ class SecureURL(SecureToken):
         if not url:
             raise ValueError("A URL is required to create a token")
 
-        payload["h"] = self._hash_url_v1(url)
+        payload[self._HASH_PARAM] = self._hash_url_v1(url)
 
         token = super().create(payload, expires, max_age)
 
@@ -60,7 +64,7 @@ class SecureURL(SecureToken):
         token = self._get_token(url)
         decoded = super().verify(token)
 
-        decoded_hash = decoded.get("h")
+        decoded_hash = decoded.get(self._HASH_PARAM)
         if not decoded_hash:
             raise InvalidToken("Secure URL token contains no URL hash")
 


### PR DESCRIPTION
This does a couple of notable things to keep the size down:

 * We use the Blake2s hash: https://www.blake2.net/
 * It's pretty new, but fast, comparably secure and most interestingly _variable length_
 * This means we can tune it's size a little
 * We pick 15 chars (60 bits of information) as it fits very neatly in 20 chars of Base 64
 
It's safe to have a pretty sketchy hash here, as it's not involved in providing security. That's handled by the JWT.

The overhead of an empty JWT (with expiry) is 105 chars. This now adds 150 chars to the length of the URL (including 9 for "&via.sec="). So the actual signing portion here increases the size by 150 - 105 - 9 = 36 chars.

