### PR TITLE
Pre-emptively add slashes to prevent ViaHTML redirects for bare hostnames

### DIFF
--- a/src/h_vialib/client.py
+++ b/src/h_vialib/client.py
@@ -98,6 +98,11 @@ class ViaClient:  # pylint: disable=too-few-public-methods
         if self._html_service_url is None:
             raise ValueError("Cannot rewrite HTML URLs without an HTML service URL")
 
+        # pywb is annoying. If we send a URL with a bare hostname and no path
+        # it will issue a redirect to the same URL with a trailing slash, which
+        # makes our token invalid. So we beat it to the punch
+        url = self._fix_bare_hostname(url)
+
         rewriter_url = urlparse(f"{self._html_service_url}/{url}")
 
         # Merge our options and the params from the URL
@@ -110,3 +115,13 @@ class ViaClient:  # pylint: disable=too-few-public-methods
         query.extend(items)
 
         return rewriter_url._replace(query=urlencode(query)).geturl()
+
+    @classmethod
+    def _fix_bare_hostname(cls, url):
+        """Add a trailing slash to URLs without a path."""
+
+        parsed_url = urlparse(url)
+        if parsed_url.path:
+            return url
+
+        return parsed_url._replace(path="/").geturl()

--- a/tests/unit/h_vialib/client_test.py
+++ b/tests/unit/h_vialib/client_test.py
@@ -61,7 +61,7 @@ class TestViaClient:
         )
 
     def test_url_for_with_html(self, client):
-        url = "http://example.com?a=1&a=2"
+        url = "http://example.com/path?a=1&a=2"
 
         final_url = client.url_for(url, "html")
 
@@ -98,6 +98,21 @@ class TestViaClient:
 
         with pytest.raises(ValueError):
             client.url_for("http://example.com", content_type)
+
+    @pytest.mark.parametrize(
+        "url,path",
+        (
+            # Note the addition of the trailing slash
+            ("http://bare.example.com", "http://bare.example.com/"),
+            # These should be left alone
+            ("http://example.com/", "http://example.com/"),
+            ("http://example.com/path", "http://example.com/path"),
+        ),
+    )
+    def test_it_fixes_html_urls_with_bare_hostnames(self, client, url, path):
+        signed_url = client.url_for(url, "html")
+
+        assert signed_url == Any.url.with_path(path)
 
     @pytest.fixture
     def client(self):


### PR DESCRIPTION
This is an attempt to beat pywb to the punch when it comes to redirects. Here is what happened before:

* Attempt to view `http://bare.hostname.com`
* Create a signed URL with that like: `http://viahtml/proxy/http://bare.hostname.com?via....`
* We check the signature and it's good and pass to `pywb` to serve the content
* `pywb` instead redirects to `http://viahtml/proxy/http://bare.hostname.com/?via....`  (_Note the trailing slash_)
* `pywb` doesn't know about our headers and does not respect it (looks like they don't use the `start_response` function)
* We don't get a surfing cookie
* Our signature isn't valid on the new URL