### PR TITLE
Make LMS mode optional

### DIFF
--- a/src/h_vialib/client.py
+++ b/src/h_vialib/client.py
@@ -38,11 +38,10 @@ class ViaDoc:  # pylint: disable=too-few-public-methods
 class ViaClient:  # pylint: disable=too-few-public-methods
     """A small wrapper to make calling Via easier."""
 
-    def __init__(self, secret, host_url, service_url=None, html_service_url=None):
+    def __init__(self, secret, service_url=None, html_service_url=None):
         """Initialize a ViaClient pointing to a `via_url` via server.
 
         :param secret: Shared secret to sign the URL
-        :param host_url: Origin of the request
         :param service_url: Location of the via server
         :param html_service_url: Location of the Via HTML presenter
         """
@@ -53,8 +52,6 @@ class ViaClient:  # pylint: disable=too-few-public-methods
         # Default via parameters
         self.options = {
             "via.client.openSidebar": "1",
-            "via.client.requestConfigFromFrame.origin": host_url,
-            "via.client.requestConfigFromFrame.ancestorLevel": "2",
             "via.external_link_mode": "new-tab",
         }
 

--- a/tests/unit/h_vialib/client_test.py
+++ b/tests/unit/h_vialib/client_test.py
@@ -41,8 +41,6 @@ class TestViaClient:
 
     DEFAULT_VALUES = {
         "via.client.openSidebar": "1",
-        "via.client.requestConfigFromFrame.origin": ORIGIN_URL,
-        "via.client.requestConfigFromFrame.ancestorLevel": "2",
         "via.external_link_mode": "new-tab",
     }
 
@@ -126,7 +124,6 @@ class TestViaClient:
         client = ViaClient(
             service_url=None,
             html_service_url=None,
-            host_url=self.ORIGIN_URL,
             secret="not_a_secret",
         )
 
@@ -153,6 +150,5 @@ class TestViaClient:
         return ViaClient(
             service_url=self.VIA_URL,
             html_service_url=self.VIAHTML_URL,
-            host_url=self.ORIGIN_URL,
             secret="not_a_secret",
         )


### PR DESCRIPTION
Make the `via.client.requestConfigFromFrame.*` options, which put the client into "LMS mode", optional.

Or rather just remove those options from `h-vialib` entirely and require the user to pass them in themselves.

LMS will pass these two options itself to `ViaClient.url_for()`'s `options` argument.

This is needed for when Via 3 is being run in a non-LMS context. In that context we don't want the client to receive the `requestConfigFromFrame` options.

See the corresponding LMS PR: https://github.com/hypothesis/lms/pull/2565