### PR TITLE
Add `ignoreOtherConfiguration` to the `hypothesisConfig`

### DIFF
--- a/src/h_vialib/client.py
+++ b/src/h_vialib/client.py
@@ -51,6 +51,7 @@ class ViaClient:  # pylint: disable=too-few-public-methods
 
         # Default via parameters
         self.options = {
+            "via.client.ignoreOtherConfiguration": "1",
             "via.client.openSidebar": "1",
             "via.external_link_mode": "new-tab",
         }

--- a/tests/unit/h_vialib/client_test.py
+++ b/tests/unit/h_vialib/client_test.py
@@ -40,6 +40,7 @@ class TestViaClient:
     ORIGIN_URL = "http://random.localhost"
 
     DEFAULT_VALUES = {
+        "via.client.ignoreOtherConfiguration": "1",
         "via.client.openSidebar": "1",
         "via.external_link_mode": "new-tab",
     }


### PR DESCRIPTION
Part of https://github.com/hypothesis/viahtml/pull/192

On the above PR viahtml make the `window.hypothesisConfig`
non-configurable and non-writable.

In addition to the above, we have added an `ignoreOtherConfiguration` to
disregard other (JSON or non-JSON) configurations and prevent options to
be merged.