### PR TITLE
Whitelist `ignoreOtherConfiguration` option for the client

### DIFF
--- a/src/h_vialib/_params.py
+++ b/src/h_vialib/_params.py
@@ -10,6 +10,7 @@ class Params:
     # From: https://h.readthedocs.io/projects/client/en/latest/publishers/config/#config-settings
     CLIENT_CONFIG_WHITELIST = {
         # Things we use now
+        "ignoreOtherConfiguration",
         "openSidebar",
         "requestConfigFromFrame",
         # Things which seem safe

--- a/tests/unit/h_vialib/_params_test.py
+++ b/tests/unit/h_vialib/_params_test.py
@@ -32,6 +32,7 @@ class TestParams:
                     # This should get moved to client params
                     "open_sidebar": True,
                     "client": {
+                        "ignoreOtherConfiguration": "allowed",
                         "focus": "allowed",
                         "random": "blocked",
                         "requestConfigFromFrame": {"anyNestedStuff": "allowed"},
@@ -43,6 +44,7 @@ class TestParams:
         assert via_params == {"any_option": 1}
         assert client_params == {
             "openSidebar": True,
+            "ignoreOtherConfiguration": "allowed",
             "focus": "allowed",
             "requestConfigFromFrame": {"anyNestedStuff": "allowed"},
             # Defaults
@@ -72,6 +74,7 @@ class TestParams:
                 "open_sidebar": True,
             },
             client_params={
+                "ignoreOtherConfiguration": "allowed",
                 "focus": "allowed",
                 "random": "blocked",
                 "requestConfigFromFrame": {"anyNestedStuff": "allowed"},
@@ -83,6 +86,7 @@ class TestParams:
                 "any_option": 1,
                 "client": {
                     "openSidebar": True,
+                    "ignoreOtherConfiguration": "allowed",
                     "focus": "allowed",
                     "requestConfigFromFrame": {"anyNestedStuff": "allowed"},
                     # Defaults


### PR DESCRIPTION
Pass this new option, `ignoreOtherConfiguration`, to the client.