### PR TITLE
Allow `contentProvider` flag to be passed through

### DIFF
--- a/src/h_vialib/_params.py
+++ b/src/h_vialib/_params.py
@@ -14,6 +14,7 @@ class Params:
         "openSidebar",
         "requestConfigFromFrame",
         # Things which seem safe
+        "contentPartner",
         "enableExperimentalNewNoteButton",
         "experimental",  # Nested value for experimental features
         "externalContainerSelector",

--- a/src/h_vialib/secure/url.py
+++ b/src/h_vialib/secure/url.py
@@ -28,7 +28,7 @@ class SecureURL(SecureToken):
 
     def create(
         self, url, payload, expires=None, max_age=None
-    ):  # pylint: disable=arguments-differ
+    ):  # pylint: disable=arguments-renamed
         """Create a signed URL which can be checked with this class.
 
         The entire URL should be added that you want to sign, without any


### PR DESCRIPTION
For:

 * https://github.com/hypothesis/private-issues/issues/110

This enables:

 * https://github.com/hypothesis/lms/pull/3941

This lets LMS set the content provider with config.