### PR TITLE
Replace jwt library

### DIFF
--- a/.cookiecutter/includes/setuptools/install_requires
+++ b/.cookiecutter/includes/setuptools/install_requires
@@ -1,2 +1,2 @@
-pyjwt
+python-jose[cryptography]
 webob

--- a/.cookiecutter/includes/tox/deps
+++ b/.cookiecutter/includes/tox/deps
@@ -1,0 +1,1 @@
+lint,tests,functests: freezegun

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     importlib_metadata;python_version<"3.8."
-    pyjwt
+    python-jose[cryptography]
     webob
 
 [options.packages.find]

--- a/src/h_vialib/secure/token.py
+++ b/src/h_vialib/secure/token.py
@@ -1,7 +1,7 @@
 """JWT based tokens which can be used to create verifiable, expiring tokens."""
 
-import jwt
-from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
+from jose import jwt
+from jose.exceptions import ExpiredSignatureError, JWTError
 
 from h_vialib.exceptions import InvalidToken, MissingToken
 from h_vialib.secure.expiry import as_expires
@@ -47,9 +47,7 @@ class SecureToken:
 
         try:
             return jwt.decode(token, self._secret, self.TOKEN_ALGORITHM)
-        except InvalidSignatureError as err:
-            raise InvalidToken("Invalid secure token") from err
         except ExpiredSignatureError as err:
             raise InvalidToken("Expired secure token") from err
-        except DecodeError as err:
-            raise InvalidToken("Malformed secure token") from err
+        except JWTError as err:
+            raise InvalidToken("Invalid secure token") from err

--- a/tests/unit/h_vialib/secure/token_test.py
+++ b/tests/unit/h_vialib/secure/token_test.py
@@ -8,12 +8,28 @@ from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
 from h_vialib.exceptions import InvalidToken, MissingToken
 from h_vialib.secure.token import SecureToken
 
+from freezegun import freeze_time
+
+
 
 def decode_token(token_string):
     return jwt.decode(token_string, "a_very_secret_secret", SecureToken.TOKEN_ALGORITHM)
 
 
 class TestSecureToken:
+
+    @freeze_time("2022-12-22")
+    @pytest.mark.parametrize("payload,expires,output", [
+        ({"a": 2}, timedelta(seconds=10), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoyLCJleHAiOjE2NzE2NjcyMTB9.k5vQWx-k_u_xRDE2wgZhh7DfK75Wt5LnOwDB4tPBA_k"),
+        ({"a": 2}, timedelta(seconds=20), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoyLCJleHAiOjE2NzE2NjcyMjB9.SZWwElky3JdiR_Xpx1pmQ2k6Kzjnxgm0-KY6AL9Q_Ws"),
+        ({"b": 5}, timedelta(seconds=10), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJiIjo1LCJleHAiOjE2NzE2NjcyMTB9.Gf1e9jLnn57iGGU4c7nit6zIZ6LWNIQTHiOzk9cLJ9c"),
+    ])
+    def test_create_output(self, token, payload, expires, output):
+        token_string = token.create(payload, expires=datetime.now() + expires)
+
+        assert token_string == output
+
+
     def test_create_works(self, token):
         expires = datetime.now() + timedelta(seconds=10)
 

--- a/tests/unit/h_vialib/secure/token_test.py
+++ b/tests/unit/h_vialib/secure/token_test.py
@@ -1,15 +1,13 @@
 from datetime import datetime, timedelta
 
-import jwt
 import pytest
+from freezegun import freeze_time
 from h_matchers import Any
-from jwt import DecodeError, ExpiredSignatureError, InvalidSignatureError
+from jose import jwt
+from jose.exceptions import ExpiredSignatureError, JWTError
 
 from h_vialib.exceptions import InvalidToken, MissingToken
 from h_vialib.secure.token import SecureToken
-
-from freezegun import freeze_time
-
 
 
 def decode_token(token_string):
@@ -17,18 +15,31 @@ def decode_token(token_string):
 
 
 class TestSecureToken:
-
     @freeze_time("2022-12-22")
-    @pytest.mark.parametrize("payload,expires,output", [
-        ({"a": 2}, timedelta(seconds=10), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoyLCJleHAiOjE2NzE2NjcyMTB9.k5vQWx-k_u_xRDE2wgZhh7DfK75Wt5LnOwDB4tPBA_k"),
-        ({"a": 2}, timedelta(seconds=20), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoyLCJleHAiOjE2NzE2NjcyMjB9.SZWwElky3JdiR_Xpx1pmQ2k6Kzjnxgm0-KY6AL9Q_Ws"),
-        ({"b": 5}, timedelta(seconds=10), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJiIjo1LCJleHAiOjE2NzE2NjcyMTB9.Gf1e9jLnn57iGGU4c7nit6zIZ6LWNIQTHiOzk9cLJ9c"),
-    ])
+    @pytest.mark.parametrize(
+        "payload,expires,output",
+        [
+            (
+                {"a": 2},
+                timedelta(seconds=10),
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoyLCJleHAiOjE2NzE2NjcyMTB9.k5vQWx-k_u_xRDE2wgZhh7DfK75Wt5LnOwDB4tPBA_k",
+            ),
+            (
+                {"a": 2},
+                timedelta(seconds=20),
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoyLCJleHAiOjE2NzE2NjcyMjB9.SZWwElky3JdiR_Xpx1pmQ2k6Kzjnxgm0-KY6AL9Q_Ws",
+            ),
+            (
+                {"b": 5},
+                timedelta(seconds=10),
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJiIjo1LCJleHAiOjE2NzE2NjcyMTB9.Gf1e9jLnn57iGGU4c7nit6zIZ6LWNIQTHiOzk9cLJ9c",
+            ),
+        ],
+    )
     def test_create_output(self, token, payload, expires, output):
         token_string = token.create(payload, expires=datetime.now() + expires)
 
         assert token_string == output
-
 
     def test_create_works(self, token):
         expires = datetime.now() + timedelta(seconds=10)
@@ -62,11 +73,7 @@ class TestSecureToken:
 
     @pytest.mark.parametrize(
         "exception",
-        (
-            InvalidSignatureError,
-            ExpiredSignatureError,
-            DecodeError,
-        ),
+        (JWTError, ExpiredSignatureError),
     )
     def test_verify_translates_errors(self, token, jwt, exception):
         jwt.decode.side_effect = exception

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
     lint,tests,functests: factory-boy
     lint,tests,functests: h-matchers
     lint,template: cookiecutter
+    lint,tests,functests: freezegun
 depends =
     coverage: tests,py{38}-tests
 commands =


### PR DESCRIPTION
python jose supports JWE.

We already use it on LMS for it's support for JWKs and the plan is to settle in just this one library for JWT related needs.