### PR TITLE
Insert `__copyright_year` into `cookiecutter.json`

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -2,7 +2,10 @@
   "template": "https://github.com/hypothesis/cookiecutters",
   "checkout": null,
   "directory": "pypackage",
-  "ignore": ["src/h_vialib/core.py", "tests/unit/h_vialib/core_test.py"],
+  "ignore": [
+    "src/h_vialib/core.py",
+    "tests/unit/h_vialib/core_test.py"
+  ],
   "extra_context": {
     "name": "h-vialib",
     "package_name": "h_vialib",
@@ -18,6 +21,7 @@
     "dependabot_pip_interval": "monthly",
     "__entry_point": "h-vialib",
     "__github_url": "https://github.com/hypothesis/h-vialib",
-    "__pypi_url": "https://pypi.org/project/h-vialib"
+    "__pypi_url": "https://pypi.org/project/h-vialib",
+    "__copyright_year": "2022"
   }
 }


### PR DESCRIPTION
This is needed to prevent the cookiecutter from updating the copyright year in the `LICENSE` file to the current year every new year. See: https://github.com/hypothesis/cookiecutters/pull/105

* * *

I automated the creation of these PRs using [Commando](https://github.com/hypothesis/commando/pull/1). I first created a script at `/tmp/insert_copyright_year.py` that, when run in the root directory of a project, inserts `__copyright_year` into the project's `cookiecutter.json` file:

```python
#!/usr/bin/env python
import json

settings = json.loads(open(".cookiecutter/cookiecutter.json", "r").read())
settings["extra_context"]["__copyright_year"] = "2022"
open(".cookiecutter/cookiecutter.json", "w").write(json.dumps(settings, indent=2))
```

I then ran Commando like this to create the PRs:

```terminal
$ commando \
  --repos $(gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false' -q '.items | .[] | .full_name' | xargs) \
  --command /tmp/insert_copyright_year.py \
  --branch insert-copyright-year \
  --commit-message-file /tmp/commit_message.txt \
  --pr-title 'Insert `__copyright_year` into `cookiecutter.json`' \
  --pr-body-file /tmp/pr_body.md
```

Rather than typing out the long `gh api` command you can instead just call the [bin/find_repos](https://github.com/hypothesis/cookiecutters/blob/main/bin/find_repos) script from the cookiecutter repo, assuming you want to send PRs to all cookiecuttered projects: `commando --repos $(bin/find_repos) --command ...`

You can also run the same command on just one repo first in order to test it before sending loads of PRs. Just run `commando --repos hypothesis/tox-envfile --command ...`.

Unfortunately there may be some incidental reformatting of `cookiecutter.json` (with no functional effect) due to rewriting the previously hand-edited file from Python.
