### PR TITLE
Fix generation of Via `/video/youtube` URLs

### DIFF
--- a/src/h_vialib/client.py
+++ b/src/h_vialib/client.py
@@ -13,7 +13,7 @@ from h_vialib.secure import Encryption, ViaSecureURL
 class ContentType(str, Enum):
     PDF = "pdf"
     HTML = "html"
-    VIDEO = "video"
+    YOUTUBE = "youtube"
 
 
 class ViaDoc:
@@ -106,7 +106,7 @@ class ViaClient:  # pylint: disable=too-few-public-methods
         # Optimisation to skip routing for documents we know the type of
         content_type_paths = {
             ContentType.PDF: "/pdf",
-            ContentType.VIDEO: "/video",
+            ContentType.YOUTUBE: "/video/youtube",
         }
         path = content_type_paths.get(doc.content_type, "/route")
 

--- a/tests/unit/h_vialib/client_test.py
+++ b/tests/unit/h_vialib/client_test.py
@@ -33,7 +33,12 @@ class TestViaClient:
     }
 
     @pytest.mark.parametrize(
-        "content_type,path", ((None, "/route"), ("pdf", "/pdf"), ("video", "/video"))
+        "content_type,path",
+        (
+            (None, "/route"),
+            (ContentType.PDF, "/pdf"),
+            (ContentType.YOUTUBE, "/video/youtube"),
+        ),
     )
     def test_url_for(self, client, content_type, path):
         url = "http://example.com&a=1&a=2"


### PR DESCRIPTION
We changed Via's `/video` endpoint to `/video/youtube`:

https://github.com/hypothesis/via/pull/980

Update h-vialib's Via URL generation to generate `/video/youtube` URLs instead of just `/video` ones.
